### PR TITLE
Allow keyword args

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TuringCallbacks"
 uuid = "ea0860ee-d0ef-45ef-82e6-cc37d6be2f9c"
 authors = ["Tor Erlend Fjelde <tor.erlend95@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/callbacks/tensorboard.jl
+++ b/src/callbacks/tensorboard.jl
@@ -109,7 +109,7 @@ function TensorBoardCallback(
     )
 end
 
-function (cb::TensorBoardCallback)(rng, model, sampler, transition, iteration)
+function (cb::TensorBoardCallback)(rng, model, sampler, transition, iteration; kwargs...)
     stats = cb.stats
     lg = cb.logger
     filter = cb.variable_filter

--- a/src/callbacks/tensorboard.jl
+++ b/src/callbacks/tensorboard.jl
@@ -75,7 +75,8 @@ function TensorBoardCallback(
     exclude = String[],
     include = String[],
     include_extras::Bool = true,
-    variable_filter = nothing
+    variable_filter = nothing,
+    kwargs...
 )
     # Create the filter
     filter = if !isnothing(variable_filter)
@@ -109,7 +110,7 @@ function TensorBoardCallback(
     )
 end
 
-function (cb::TensorBoardCallback)(rng, model, sampler, transition, iteration; kwargs...)
+function (cb::TensorBoardCallback)(rng, model, sampler, transition, iteration, state; kwargs...)
     stats = cb.stats
     lg = cb.logger
     filter = cb.variable_filter


### PR DESCRIPTION
Catches cases where AbstractMCMC versions above 3.0 require a callback of the form

```
callback(rng, model, sampler, sample, state, iteration; kwargs...)
```