### PR TITLE
update to latest turing

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -15,7 +15,7 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,39 +4,36 @@ on:
     branches:
       - main
   pull_request:
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+# Cancel existing tests on the same PR if a new commit is added to a pull request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+          version: "1"
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.cov
 *.jl.mem
 /docs/build/
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TuringCallbacks"
 uuid = "ea0860ee-d0ef-45ef-82e6-cc37d6be2f9c"
 authors = ["Tor Erlend Fjelde <tor.erlend95@gmail.com> and contributors"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -27,7 +27,7 @@ OnlineStats = "1.5"
 Reexport = "0.2, 1.0"
 Requires = "1"
 TensorBoardLogger = "0.1.22"
-Turing = "0.29, 0.30, 0.31, 0.32, 0.33"
+Turing = "0.29-0.39"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -21,13 +21,13 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 TuringCallbacksTuringExt = "Turing"
 
 [compat]
-DataStructures = "0.18-0.19"
+DataStructures = "0.18 - 0.19"
 DocStringExtensions = "0.8, 0.9"
 OnlineStats = "1.5"
 Reexport = "0.2, 1.0"
 Requires = "1"
 TensorBoardLogger = "0.1.22"
-Turing = "0.29-0.39"
+Turing = "0.39"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 TuringCallbacksTuringExt = "Turing"
 
 [compat]
-DataStructures = "0.18"
+DataStructures = "0.18-0.19"
 DocStringExtensions = "0.8, 0.9"
 OnlineStats = "1.5"
 Reexport = "0.2, 1.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 TuringCallbacks = "ea0860ee-d0ef-45ef-82e6-cc37d6be2f9c"
+
+[compat]
+Documenter = "1"

--- a/ext/TuringCallbacksTuringExt.jl
+++ b/ext/TuringCallbacksTuringExt.jl
@@ -55,7 +55,7 @@ end
 
 function TuringCallbacks.hyperparam_metrics(
     model,
-    sampler::Turing.Sampler{<:Turing.Inference.NUTS}
+    sampler::DynamicPPL.Sampler{<:Turing.Inference.NUTS}
 )
     return [
         "extras/acceptance_rate/stat/Mean",

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 TensorBoardLogger = "899adc3e-224a-11e9-021f-63837185c80f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
@@ -6,6 +7,6 @@ ValueHistories = "98cad3c8-aec3-5f06-8e41-884608649ab7"
 
 [compat]
 TensorBoardLogger = "0.1.26"
+Test = "1.11.0"
 Turing = "0.39.10"
 ValueHistories = "0.5.4"
-Test = "1.11.0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,3 +3,9 @@ TensorBoardLogger = "899adc3e-224a-11e9-021f-63837185c80f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 ValueHistories = "98cad3c8-aec3-5f06-8e41-884608649ab7"
+
+[compat]
+TensorBoardLogger = "0.1.26"
+Turing = "0.39.10"
+ValueHistories = "0.5.4"
+Test = "1.11.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using DynamicPPL
 using Turing
 using TuringCallbacks
 using TensorBoardLogger, ValueHistories


### PR DESCRIPTION
It is likely that Turing 0.40 will break this, because this uses a lot of `Turing.Inference.foo` functions which should really be internal, but 0.39 is OK for now.